### PR TITLE
Remove redundant skills path from plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,5 +6,5 @@
     "name": "Rich"
   },
   "license": "MIT",
-  "keywords": ["dotnet", "nuget", "package", "assembly"]
+  "keywords": ["dotnet", "nuget", "package", "library"]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,6 +6,5 @@
     "name": "Rich"
   },
   "license": "MIT",
-  "keywords": ["dotnet", "nuget", "package", "assembly"],
-  "skills": "./skills/"
+  "keywords": ["dotnet", "nuget", "package", "assembly"]
 }


### PR DESCRIPTION
## Summary
- Remove the `skills` property from `plugin.json` — it's redundant since `skills/` at the plugin root is auto-discovered by convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)