### PR TITLE
Bump version to 0.6.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "dotnet-skills",
       "source": "./",
       "description": ".NET skills for coding assistants",
-      "version": "0.6.7"
+      "version": "0.6.8"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dotnet-skills",
   "description": ".NET skills for coding assistants",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "author": {
     "name": "Rich"
   },

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.6.7
+version: 0.6.8
 description: Query .NET APIs across NuGet packages, platform libraries, and local files. Search for types, list API surfaces, compare and diff versions, find extension methods and implementors. Use whenever you need to answer questions about .NET library contents.
 ---
 


### PR DESCRIPTION
## Summary

- Bump plugin.json, marketplace.json, and SKILL.md to 0.6.8

Companion to https://github.com/richlander/dotnet-inspect/pull/273

🤖 Generated with [Claude Code](https://claude.com/claude-code)