### PR TITLE
Add markdown lint workflow for PRs

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,17 @@
+name: Markdown Lint
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: '**/*.md'

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,2 @@
+# Long lines OK (tables, links)
+MD013: false

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ See:
 
 ## Available Skills
 
-| Skill | Description |
-|-------|-------------|
+| Skill            | Description                                |
+|------------------|--------------------------------------------|
 | `dotnet-inspect` | Inspect .NET assemblies and NuGet packages |
 
 ## Installation


### PR DESCRIPTION
Add a GitHub Actions workflow that runs [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2-action) on pull requests that touch markdown files.

## Changes

- **`.github/workflows/markdownlint.yml`** — Workflow using `DavidAnson/markdownlint-cli2-action@v19`, triggered on PRs with `**/*.md` path filter
- **`.markdownlint.yaml`** — Config disabling MD013 (line length) for tables/links
- **`README.md`** — Fixed table alignment to pass MD060

Simplified from the workflow in [dotnet-inspect](https://github.com/richlander/dotnet-inspect).