### PR TITLE
Sync skill to v0.7.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "dotnet-skills",
       "source": "./",
       "description": ".NET skills for coding assistants",
-      "version": "0.6.9"
+      "version": "0.7.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dotnet-skills",
   "description": ".NET skills for coding assistants",
-  "version": "0.6.9",
+  "version": "0.7.1",
   "author": {
     "name": "Rich"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dotnet-skills",
   "description": ".NET skills for coding assistants",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": {
     "name": "Rich"
   },

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.7.1
+version: 0.7.2
 description: Query .NET APIs across NuGet packages, platform libraries, and local files. Search for types, list API surfaces, compare and diff versions, find extension methods and implementors. Use whenever you need to answer questions about .NET library contents.
 ---
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.6.9
+version: 0.7.1
 description: Query .NET APIs across NuGet packages, platform libraries, and local files. Search for types, list API surfaces, compare and diff versions, find extension methods and implementors. Use whenever you need to answer questions about .NET library contents.
 ---
 
@@ -11,12 +11,13 @@ Query .NET library APIs — the same commands work across NuGet packages, platfo
 ## Quick Decision Tree
 
 - **Code broken?** → `diff --package Foo@old..new` first, then `member`
+- **What's new in a .NET preview?** → `diff --platform System.Runtime@P2..P3 --additive` per framework library
 - **What types exist?** → `type --package Foo` (discover types in a package or library)
 - **What members does a type have?** → `member Type --package Foo` (compact table by default)
 - **What does a type look like?** → `type Type --package Foo` (tree view for single type)
 - **What are the method signatures?** → `member Type --package Foo -m Method` (full signatures + docs)
 - **What is the source/IL?** → `member Type --package Foo -m Method:1 -v:d` (Source, Lowered C#, IL)
-- **Where is the source code?** → `source Type --package Foo` (SourceLink URLs), `source Type Member` (with line numbers)
+- **Where is the source code?** → `source Type --package Foo` (SourceLink URLs), `source Type -m Member` (with line numbers)
 - **Want raw source content?** → `source Type --package Foo --cat` (fetches and prints source files)
 - **What constructors exist?** → `member 'Type<T>' --package Foo -m .ctor` (use `<T>` not `<>`)
 - **How many overloads?** → `member Type --package Foo --show-index` (shows `Name:N` indices)
@@ -30,6 +31,7 @@ Query .NET library APIs — the same commands work across NuGet packages, platfo
 - **"What types are in this package?"** — `type` discovers types, `find` searches by pattern
 - **"What members does this type have?"** — `member` for methods/properties/events (docs on by default)
 - **"What changed between versions?"** — `diff` classifies breaking/additive changes
+- **"What new APIs shipped in this preview?"** — `diff --platform System.Runtime@prev..current --additive` per framework library
 - **"This code uses an old API — fix it"** — `diff` the old..new version, then `member` to see the new API
 - **"What extends this type?"** — `extensions` finds extension methods/properties (`--reachable` for transitive)
 - **"What implements this interface?"** — `implements` finds concrete types
@@ -40,11 +42,13 @@ Query .NET library APIs — the same commands work across NuGet packages, platfo
 - **"What's the latest on NuGet?"** — `Foo --latest-version` (always queries NuGet — like `docker pull`)
 - **"What versions exist?"** — `Foo --versions` (list all published versions)
 - **"What TFMs are available?"** — `package Foo --tfms`, then `type --package Foo --tfm net8.0`
+- **"Where is the source code?"** — `source` returns SourceLink URLs; add member name for line numbers
+- **"Show me the actual source?"** — `source Type --package Foo --cat` fetches and prints source file contents
 - **"Show me something cool"** — `demo` runs curated showcase queries
 
 ## Key Patterns
 
-Default output is compact columnar tables (like `docker images` or `git log --oneline`). No flags needed for scanning:
+Default output is **markdown** — headings, tables, and field lists that render well in terminals, editors, and LLM contexts. No flags needed:
 
 ```bash
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json    # scan members
@@ -52,12 +56,12 @@ dnx dotnet-inspect -y -- type --package System.Text.Json                     # s
 dnx dotnet-inspect -y -- diff --package System.CommandLine@2.0.0-beta4.22272.1..2.0.3  # triage changes
 ```
 
-Four formatters: **oneline** (default), **plaintext**, **markdown** (`-v` or `--markdown`), **json** (`--json`). Verbosity (`-v:q/m/n/d`) controls which sections are included; formatter controls how they render. They compose freely — except `--oneline` and `-v` cannot be combined.
+Default format is **markdown** — no flags needed. Optional formats: **oneline** (`--oneline`), **plaintext** (`--plaintext`), **json** (`--json`). Verbosity (`-v:q/m/n/d`) controls which sections are included; formatter controls how they render. They compose freely — except `--oneline` and `-v` cannot be combined.
 
 ```bash
-dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -v:m  # markdown with docs
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -v:d  # detailed (source/IL)
 dnx dotnet-inspect -y -- System.Text.Json -v:n --plaintext                      # all local sections, plaintext
+dnx dotnet-inspect -y -- type --package System.Text.Json --oneline              # compact columnar output
 ```
 
 Use `diff` first when fixing broken code — triage changes, then drill into specifics:
@@ -65,6 +69,27 @@ Use `diff` first when fixing broken code — triage changes, then drill into spe
 ```bash
 dnx dotnet-inspect -y -- diff --package System.CommandLine@2.0.0-beta4.22272.1..2.0.3  # what changed?
 dnx dotnet-inspect -y -- member Command --package System.CommandLine@2.0.3               # new API surface
+```
+
+## Platform Diffs & Release Notes
+
+For framework libraries (System.*, Microsoft.AspNetCore.*), use `--platform` instead of `--package`. This is the primary workflow for .NET release notes — diff each framework library between preview versions:
+
+```bash
+dnx dotnet-inspect -y -- diff --platform System.Runtime@P2..P3 --additive        # what's new?
+dnx dotnet-inspect -y -- diff --platform System.Net.Http@P2..P3 --additive       # per-library
+dnx dotnet-inspect -y -- diff --platform System.Text.Json@9.0.0..10.0.0          # across major versions
+```
+
+**Multi-library packages:** `diff --package` works across all libraries in a package (e.g., `Microsoft.Azure.SignalR` with multiple DLLs). For framework ref packages like `Microsoft.NETCore.App.Ref`, prefer `--platform` per-library since it resolves from installed packs.
+
+**Nightly/preview packages from custom feeds:** The `--source` flag works for version listing but not package downloads. Pre-populate the NuGet cache instead:
+
+```bash
+# Pre-populate cache (fails with NU1213 but downloads the package)
+dotnet add package Microsoft.NETCore.App.Ref --version <version> --source <feed-url>
+# Then use normally — resolves from NuGet cache
+dnx dotnet-inspect -y -- diff --platform System.Runtime@P2..P3 --additive
 ```
 
 ## Version Resolution (Docker-style)
@@ -181,12 +206,4 @@ Use `dnx` (like `npx`). Always use `-y` and `--` to prevent interactive prompts:
 
 ```bash
 dnx dotnet-inspect -y -- <command>
-```
-
-## Full Documentation
-
-For the full mental model, structured queries, and migration workflow:
-
-```bash
-dnx dotnet-inspect -y -- llmstxt
 ```


### PR DESCRIPTION
- Sync SKILL.md from dotnet-inspect: markdown default, optional formats (json, oneline, plaintext), Platform Diffs section
- Bump plugin.json and marketplace.json to 0.7.2