### PR TITLE
Sync skills from upstream repos for v0.7.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "dotnet-skills",
       "source": "./",
       "description": ".NET skills for coding assistants",
-      "version": "0.7.4"
+      "version": "0.7.5"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dotnet-skills",
   "description": ".NET skills for coding assistants",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "author": {
     "name": "Rich"
   },

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.7.2
+version: 0.7.5
 description: Query .NET APIs across NuGet packages, platform libraries, and local files. Search for types, list API surfaces, compare and diff versions, find extension methods and implementors. Use whenever you need to answer questions about .NET library contents.
 ---
 
@@ -23,6 +23,7 @@ Query .NET library APIs — the same commands work across NuGet packages, platfo
 - **How many overloads?** → `member Type --package Foo --show-index` (shows `Name:N` indices)
 - **What does this package depend on?** → `depends --package Foo`
 - **What does this type inherit?** → `depends 'INumber<TSelf>'`
+- **Want a dependency diagram?** → `depends --mermaid` (standalone) or `depends --markdown --mermaid` (embedded)
 - **What metadata fields exist?** → `-S Section --fields "PDB*"` (structured query, no DSL)
 - **What version is available?** → `Foo --version` (cache-first), `Foo --latest-version` (always NuGet), `Foo --versions` (list all)
 
@@ -36,6 +37,7 @@ Query .NET library APIs — the same commands work across NuGet packages, platfo
 - **"What extends this type?"** — `extensions` finds extension methods/properties (`--reachable` for transitive)
 - **"What implements this interface?"** — `implements` finds concrete types
 - **"What does this type depend on?"** — `depends` walks type hierarchy, package deps, or library refs
+- **"Show dependencies as a diagram"** — `depends --mermaid` for standalone mermaid, `--markdown --mermaid` for embedded
 - **"Where is the source code?"** — `source` returns SourceLink URLs; add member name for line numbers
 - **"What version/metadata does this have?"** — `package` and `library` inspect metadata
 - **"What version is available?"** — `Foo --version` (fast, cache-first — like `docker run`)
@@ -56,12 +58,14 @@ dnx dotnet-inspect -y -- type --package System.Text.Json                     # s
 dnx dotnet-inspect -y -- diff --package System.CommandLine@2.0.0-beta4.22272.1..2.0.3  # triage changes
 ```
 
-Default format is **markdown** — no flags needed. Optional formats: **oneline** (`--oneline`), **plaintext** (`--plaintext`), **json** (`--json`). Verbosity (`-v:q/m/n/d`) controls which sections are included; formatter controls how they render. They compose freely — except `--oneline` and `-v` cannot be combined.
+Default format is **markdown** — no flags needed. Optional formats: **oneline** (`--oneline`), **plaintext** (`--plaintext`), **json** (`--json`), **mermaid** (`--mermaid`). Verbosity (`-v:q/m/n/d`) controls which sections are included; formatter controls how they render. They compose freely — except `--oneline` and `-v` cannot be combined.
 
 ```bash
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -v:d  # detailed (source/IL)
 dnx dotnet-inspect -y -- System.Text.Json -v:n --plaintext                      # all local sections, plaintext
 dnx dotnet-inspect -y -- type --package System.Text.Json --oneline              # compact columnar output
+dnx dotnet-inspect -y -- depends Stream --mermaid                               # standalone mermaid diagram
+dnx dotnet-inspect -y -- depends Stream --markdown --mermaid                    # mermaid embedded in markdown
 ```
 
 Use `diff` first when fixing broken code — triage changes, then drill into specifics:
@@ -143,6 +147,22 @@ dnx dotnet-inspect -y -- library System.Text.Json -D --tree           # full sch
 dnx dotnet-inspect -y -- System.Text.Json -S Symbols                  # render one section
 dnx dotnet-inspect -y -- System.Text.Json -S Symbols --fields "PDB*"  # project specific fields
 dnx dotnet-inspect -y -- type System.Text.Json --columns Kind,Type    # project specific columns
+```
+
+## Mermaid Diagrams
+
+The `depends` command supports `--mermaid` for Mermaid diagram output. Two modes:
+
+| Flags | Output | Use case |
+| ----- | ------ | -------- |
+| `--mermaid` | Standalone mermaid (`graph TD`) | Pipe to `mmdc`, embed in tooling |
+| `--markdown --mermaid` | Mermaid fenced blocks inside markdown | Render in GitHub, VS Code, docs |
+
+```bash
+dnx dotnet-inspect -y -- depends Stream --mermaid                               # type hierarchy as mermaid
+dnx dotnet-inspect -y -- depends Stream --markdown --mermaid                    # embedded in markdown
+dnx dotnet-inspect -y -- depends --library System.Text.Json --mermaid           # assembly reference graph
+dnx dotnet-inspect -y -- depends --package Markout --mermaid                    # package dependency graph
 ```
 
 ## Search Scope

--- a/skills/dotnet-install/SKILL.md
+++ b/skills/dotnet-install/SKILL.md
@@ -2,47 +2,13 @@
 name: dotnet-install
 description: >
   Build, install, list, and remove .NET tools using dotnet-install.
-  Use when the user wants to install, manage, or run .NET tools.
-  Covers NuGet packages, GitHub repos, git URLs, and local projects.
 ---
 
 # dotnet-install
 
-## When to Use
-
-- The user wants to install a .NET tool to their PATH
-- The user wants to list, update, remove, or search for .NET tools
-- The user wants to run a .NET tool without installing it (npx-style)
-- The user needs help setting up dotnet-install itself
-
-## When Not to Use
-
-- The user is managing NuGet package references in a project (use `dotnet add package`)
-- The user wants the traditional `dotnet tool install -g` workflow
-- The user is working with .NET SDKs or runtimes (use `dotnet-install.sh` from Microsoft)
-
-## Check if dotnet-install is available
-
-```bash
-dotnet-install --version
-```
-
-If not installed, install it:
-
-```bash
-# Option 1: via dotnet tool (requires .NET 10+ SDK)
-dotnet tool install -g dotnet-install
-dotnet-install doctor --fix
-
-# Option 2: install script (Unix only, no SDK required)
-curl -sSfL https://github.com/richlander/dotnet-install/raw/refs/heads/main/install.sh | sh
-```
-
-If already installed, update to the latest version:
-
-```bash
-dotnet-install update dotnet-install
-```
+Install .NET executables to PATH — like `cargo install`
+and `go install`. Build from source, install from NuGet,
+or clone from GitHub.
 
 ## Install sources
 
@@ -51,50 +17,33 @@ Each source requires an explicit flag. With no arguments,
 installs it (like `dotnet publish`). With nothing to act on,
 it prints help.
 
-### From local source (builds)
-
-Requires .NET SDK.
-
 ```bash
-dotnet-install                      # current directory (like dotnet publish)
-dotnet-install src/my-tool          # positional path
-dotnet-install --project src/my-tool # explicit (like dotnet run --project)
-dotnet-install app.cs               # file-based app (.NET 10+)
-```
+# Local project (default — works like dotnet publish)
+dotnet-install                                # current directory
+dotnet-install src/my-tool                    # positional path
+dotnet-install --project src/my-tool          # explicit (like dotnet run --project)
+dotnet-install app.cs                         # file-based app
 
-`--path` is an alias for `--project`.
-
-### From NuGet (pre-built, no SDK required)
-
-```bash
+# NuGet package (no SDK required)
 dotnet-install --package dotnetsay
-dotnet-install --package dotnet-counters@9.0.0
-```
+dotnet-install --package dotnet-counters@9.0.0  # pinned version
 
-### From GitHub (clones and builds)
-
-Requires git and .NET SDK.
-
-```bash
+# GitHub repository
 dotnet-install --github owner/repo            # tracks default branch, updatable
 dotnet-install --github owner/repo --branch main   # tracks branch, updatable
 dotnet-install --github owner/repo --tag v2.0      # pinned, no updates
 dotnet-install --github owner/repo --rev abc123    # pinned, no updates
 dotnet-install --github owner/repo@v2.0            # shorthand, pinned
 dotnet-install --github owner/repo --ssh           # clone via SSH
-```
 
-### From any git URL (clones and builds)
-
-Requires git and .NET SDK.
-
-```bash
+# Any git URL
 dotnet-install --git https://example.com/repo.git
 dotnet-install --git https://example.com/repo.git --tag v1.0
 ```
 
-When combined with `--github` or `--git`, `--project`
-specifies a sub-path within the cloned repository.
+`--path` is an alias for `--project`. When combined with
+`--github` or `--git`, `--project` specifies a sub-path
+within the cloned repository.
 
 ## Git ref options
 
@@ -112,53 +61,40 @@ To change versions, uninstall and reinstall.
 ## Subcommands
 
 ```bash
-dotnet-install ls                  # list installed tools
-dotnet-install rm <tool>           # remove a tool
-dotnet-install update [tool]       # update one or all tools
-dotnet-install search <query>      # search NuGet for tool packages
-dotnet-install info <tool>         # show tool details and provenance
-dotnet-install outdated            # check for newer versions
-dotnet-install run <pkg> [args]    # run without installing (npx-style)
-dotnet-install doctor [--fix]      # diagnose and fix PATH/config
-dotnet-install env                 # print environment info
-dotnet-install config [key] [val]  # view/set configuration
-dotnet-install completion <shell>  # shell completion setup
+dotnet-install ls                # list installed tools
+dotnet-install rm <tool>         # remove a tool
+dotnet-install update [tool]     # update one or all tools
+dotnet-install search <query>    # search NuGet
+dotnet-install info <tool>       # show tool details
+dotnet-install outdated          # check for newer versions
+dotnet-install run <pkg> [args]  # run without installing
+dotnet-install doctor            # diagnose PATH and config
+dotnet-install env               # print environment info
+dotnet-install completion <sh>   # shell completion setup
 ```
 
 ## Install directory
 
 Tools are installed to `~/.dotnet/bin/` by default.
-
-| Override | Effect |
-|----------|--------|
-| `-o <dir>` | Custom output directory |
-| `--local-bin` | Use `~/.local/bin/` instead |
-| `DOTNET_TOOL_BIN` env var | Persistent override |
+Override with `DOTNET_TOOL_BIN` env var, `-o <dir>`,
+or `--local-bin` (uses `~/.local/bin/`).
 
 ## PATH configuration
 
 `dotnet-install` uses a dedicated env file (`~/.dotnet/bin/env`)
-sourced from the shell rc file, following the same pattern as
-Rustup (`~/.cargo/env`). Run `dotnet-install doctor --fix` to
-configure PATH automatically. To activate in the current shell:
+that is sourced from the shell's rc file. Run
+`dotnet-install doctor --fix` to configure PATH automatically.
+To activate in the current shell without restarting:
 
 ```bash
-. "$HOME/.dotnet/bin/env"            # sh/bash/zsh
-source "$HOME/.dotnet/bin/env.fish"  # fish
-```
-
-## Configuration
-
-```bash
-dotnet-install config                         # show all settings
-dotnet-install config tip.quiet true          # suppress PATH tips
-dotnet-install config manage-global-tools true  # drain dotnet global tools via doctor
+. "$HOME/.dotnet/bin/env"          # sh/bash/zsh
+source "$HOME/.dotnet/bin/env.fish" # fish
 ```
 
 ## Reliable behavior
 
-- Git updates verify that remote history is a
-  continuation of local history. If a force push
+- Git updates verify that the remote history is a
+  continuation of the local history. If a force push
   is detected, the update is refused — the user must
   uninstall and reinstall the tool.
 - Pinned installs (`--tag`, `--rev`, `@ref`) are
@@ -171,5 +107,3 @@ dotnet-install config manage-global-tools true  # drain dotnet global tools via 
   tool targets an older runtime.
 - `--require-sourcelink` enforces SourceLink metadata
   in installed assemblies.
-- Missing prereqs (git, .NET SDK) produce actionable
-  error messages with install links.


### PR DESCRIPTION
Syncs both skills from their upstream source repos.

### Changes
- **dotnet-inspect**: Synced to v0.7.5 from [richlander/dotnet-inspect](https://github.com/richlander/dotnet-inspect) — adds mermaid diagram support (`--mermaid` flag, new section, decision tree entries)
- **dotnet-install**: Synced to upstream embedded skill from [richlander/dotnet-install](https://github.com/richlander/dotnet-install) (`src/dotnet-install/skill.md`)
- Bumps plugin version from 0.7.4 → 0.7.5