### PR TITLE
Update dotnet-inspect skill to 0.9.2

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -22,11 +22,7 @@ dnx dotnet-inspect -y -- skill
 
 Prefer that embedded skill output over this marketplace bootstrap file when commands or section names differ. It is versioned with the tool and prevents stale skill guidance after breaking CLI changes.
 
-Default output is Markdown. Use Markdown for readable evidence with headings, section boundaries, table headers, and code fences that are easy to quote. Use `--oneline` for compact tabular output like `docker images` when you need one result per row. Use `--json` for structured automation. Use `-v:d` when you need source/decompiled C#/IL detail.
-
-Use the query system when you need a specific slice instead of a fixed template. `-D` discovers sections/columns; `-S Section` selects sections by name or wildcard, such as `-S "Async*"`; `--columns` and `--fields` project values. This serves a similar role to Go templates, but you discover the available shape first instead of guessing field names.
-
-Use built-in limiters before shell pipes. `-n N` and numeric shorthand like `-6` work like `head`; `--tail N` works like `tail`; add `--rows` to make head counts cap Markdown table data rows instead of output lines, for example `--rows -n 10` or `--rows -10`. Use `--count` to count rows in one selected table section. Command-specific limiters also matter: `-t N` limits type/find results, `-m N` limits member results, and `--versions N` limits package version lists.
+Default output is Markdown. Use `--oneline` for compact tabular output like `docker images`, and `--json` for structured automation. For output, query, and limiter details such as `-D`, `-S "Async*"`, `-n`, `--tail`, and `--rows`, run the embedded guide.
 
 ## Fast starts
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -22,9 +22,11 @@ dnx dotnet-inspect -y -- skill
 
 Prefer that embedded skill output over this marketplace bootstrap file when commands or section names differ. It is versioned with the tool and prevents stale skill guidance after breaking CLI changes.
 
-Default output is Markdown. Use Markdown for readable evidence with headings, section boundaries, table headers, and code fences that are easy to quote. Use `--plaintext` for text-only output, `--oneline` for compact one-result-per-line output, `--json` for structured automation, and `-v:d` when you need source/decompiled C#/IL detail.
+Default output is Markdown. Use Markdown for readable evidence with headings, section boundaries, table headers, and code fences that are easy to quote. Use `--oneline` for compact tabular output like `docker images` when you need one result per row. Use `--json` for structured automation. Use `-v:d` when you need source/decompiled C#/IL detail.
 
-Use built-in limiters before shell pipes. `-n N` and shorthand like `-6` limit output lines; `--tail N` keeps the last N lines; `--rows -n N` or `--rows -6` caps data rows per rendered Markdown table while preserving headings and table headers; `--count` counts rows in one selected table section. Command-specific limiters also matter: `-t N` limits type/find results, `-m N` limits member results, and `--versions N` limits package version lists.
+Use the query system when you need a specific slice instead of a fixed template. `-D` discovers sections/columns; `-S Section` selects sections; `--columns` and `--fields` project values. This serves a similar role to Go templates, but you discover the available shape first instead of guessing field names.
+
+Use built-in limiters before shell pipes. `-n N` and numeric shorthand like `-6` work like `head`; `--tail N` works like `tail`; add `--rows` to make head counts cap Markdown table data rows instead of output lines, for example `--rows -n 10` or `--rows -10`. Use `--count` to count rows in one selected table section. Command-specific limiters also matter: `-t N` limits type/find results, `-m N` limits member results, and `--versions N` limits package version lists.
 
 ## Fast starts
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -24,7 +24,7 @@ Prefer that embedded skill output over this marketplace bootstrap file when comm
 
 Default output is Markdown. Use Markdown for readable evidence with headings, section boundaries, table headers, and code fences that are easy to quote. Use `--oneline` for compact tabular output like `docker images` when you need one result per row. Use `--json` for structured automation. Use `-v:d` when you need source/decompiled C#/IL detail.
 
-Use the query system when you need a specific slice instead of a fixed template. `-D` discovers sections/columns; `-S Section` selects sections; `--columns` and `--fields` project values. This serves a similar role to Go templates, but you discover the available shape first instead of guessing field names.
+Use the query system when you need a specific slice instead of a fixed template. `-D` discovers sections/columns; `-S Section` selects sections by name or wildcard, such as `-S "Async*"`; `--columns` and `--fields` project values. This serves a similar role to Go templates, but you discover the available shape first instead of guessing field names.
 
 Use built-in limiters before shell pipes. `-n N` and numeric shorthand like `-6` work like `head`; `--tail N` works like `tail`; add `--rows` to make head counts cap Markdown table data rows instead of output lines, for example `--rows -n 10` or `--rows -10`. Use `--count` to count rows in one selected table section. Command-specific limiters also matter: `-t N` limits type/find results, `-m N` limits member results, and `--versions N` limits package version lists.
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: dotnet-inspect
-version: 0.9.0
-description: Bootstrap skill for dotnet-inspect. Use it to query .NET APIs, packages, platform libraries, SourceLink, dependencies, and version-to-version API changes.
+version: 0.9.2
+description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, SourceLink/symbol provenance, and version-to-version API changes.
 ---
 
 # dotnet-inspect
 
-Use dotnet-inspect when you need evidence about .NET libraries instead of guessing: API signatures, package contents, extension methods, implementors, SourceLink URLs, dependencies, or version-to-version API changes.
+Use dotnet-inspect when you need evidence instead of guesses for .NET packages, platform libraries, local assemblies, APIs, dependencies, SourceLink/symbol provenance, or version-to-version API changes.
 
-Invoke through `dnx` unless the tool is already installed:
+Invoke with `dnx`:
 
 ```bash
 dnx dotnet-inspect -y -- <command>
@@ -22,7 +22,9 @@ dnx dotnet-inspect -y -- skill
 
 Prefer that embedded skill output over this marketplace bootstrap file when commands or section names differ. It is versioned with the tool and prevents stale skill guidance after breaking CLI changes.
 
-Default output is Markdown. Use `--oneline` to scan, `--json` for structured data, `--count` to count one selected table section, and `-n N` to limit output without losing headers.
+Default output is Markdown. Use Markdown for readable evidence with headings, section boundaries, table headers, and code fences that are easy to quote. Use `--plaintext` for text-only output, `--oneline` for compact one-result-per-line output, `--json` for structured automation, and `-v:d` when you need source/decompiled C#/IL detail.
+
+Use built-in limiters before shell pipes. `-n N` and shorthand like `-6` limit output lines; `--tail N` keeps the last N lines; `--rows -n N` or `--rows -6` caps data rows per rendered Markdown table while preserving headings and table headers; `--count` counts rows in one selected table section. Command-specific limiters also matter: `-t N` limits type/find results, `-m N` limits member results, and `--versions N` limits package version lists.
 
 ## Fast starts
 


### PR DESCRIPTION
## Summary
- update the marketplace dotnet-inspect SKILL.md to 0.9.2
- align the reusable intro/description with the embedded skill
- keep the marketplace skill brief as a bootstrap that points to `dnx dotnet-inspect -y -- skill` for detailed output, query, limiter, and workflow guidance

## Validation
- git diff --check -- skills/dotnet-inspect/SKILL.md