### PR TITLE
Update plugin metadata to 0.9.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "dotnet-skills",
       "source": "./",
       "description": ".NET skills for coding assistants",
-      "version": "0.9.0"
+      "version": "0.9.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dotnet-skills",
   "description": ".NET skills for coding assistants",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "author": {
     "name": "Richard Lander"
   },


### PR DESCRIPTION
## Summary
- bump Claude plugin metadata versions from 0.9.0 to 0.9.2 to match the dotnet-inspect skill update

## Validation
- jq empty .claude-plugin/plugin.json .claude-plugin/marketplace.json