### PR TITLE
Recommend -n N --rows for the prioritized top-findings digest

### DIFF
--- a/skills/dotnet-allocation-triage/SKILL.md
+++ b/skills/dotnet-allocation-triage/SKILL.md
@@ -38,7 +38,13 @@ dotnet build -c Release
 dnx dotnet-inspect -y -- library bin/Release/<tfm>/<Assembly>.dll -S "Performance Triage"
 ```
 
-For machine-readable output add `--json` (or `--tsv`/`--jsonl`); cap rows with `-n <N> --rows`.
+The section is already ordered to surface pay-dirt first — in-loop allocations, then by confidence, then by call-graph reach. So for a quick top-findings view, cap the rows and you get the highest-value sites directly, no filtering needed:
+
+```bash
+dnx dotnet-inspect -y -- library bin/Release/<tfm>/<Assembly>.dll -S "Performance Triage" -n 15 --rows
+```
+
+For machine-readable output add `--json` (or `--tsv`/`--jsonl`) — useful when you want every row to group or filter by shape yourself.
 
 ### Read the table
 


### PR DESCRIPTION
Small skill refinement: Performance Triage is already ordered pay-dirt first (in-loop → confidence → reach), so `-n <N> --rows` gives the highest-value sites directly. Reduces the need for `--json` + external filtering in the common 'show me the top findings' case (observed in the agent eval). `--json` guidance kept for when you want every row.

Follow-up to #22.